### PR TITLE
bug: Change _build_model to take a dictionary.

### DIFF
--- a/src/commissaire_service/storage/__init__.py
+++ b/src/commissaire_service/storage/__init__.py
@@ -15,7 +15,6 @@
 
 import fnmatch
 import importlib
-import json
 
 import commissaire.models as models
 
@@ -120,7 +119,7 @@ class StorageService(CommissaireService):
         :rtype: commissaire_service.storage.models.Model
         """
         model_type = self._model_types[model_type_name]
-        return model_type.new(**model_json_data)
+        return model_type.new(**model_kwargs)
 
     def on_save(self, message, model_type_name, model_json_data):
         """

--- a/src/commissaire_service/storage/__init__.py
+++ b/src/commissaire_service/storage/__init__.py
@@ -108,19 +108,19 @@ class StorageService(CommissaireService):
         self._manager.register_store_handler(
             handler_type, config, *matched_types)
 
-    def _build_model(self, model_type_name, model_json_data):
+    def _build_model(self, model_type_name, model_kwargs):
         """
-        Builds a model instance from a type name and JSON representation.
+        Builds a model instance from a type name and kwargs.
 
         :param model_type_name: Model type for the JSON data
         :type model_type_name: str
-        :param model_json_data: JSON representation of a model
-        :type model_json_data: str
+        :param model_kwargs: Keyword args to pass to the model
+        :type model_kwargs: dict
         :returns: a model instance
         :rtype: commissaire_service.storage.models.Model
         """
         model_type = self._model_types[model_type_name]
-        return model_type.new(**json.loads(model_json_data))
+        return model_type.new(**model_json_data)
 
     def on_save(self, message, model_type_name, model_json_data):
         """


### PR DESCRIPTION
Since ``_wrap_on_message`` will always load the json data into a dictionary
before passing it to the underlying implementation there was no need for
``_build_model`` to attempt to load the input as a json string.