### PR TITLE
storage: commissaire-storage-service now installs as a bin.

### DIFF
--- a/conf/storage.conf
+++ b/conf/storage.conf
@@ -1,0 +1,8 @@
+{
+  "storage-handlers": [{
+      "name": "commissaire.storage.etcd",
+      "server_url": "https://127.0.0.1:2379",
+      "models": ["*"]
+    }
+  ]
+}

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,10 @@ setup(
     install_requires=install_requires,
     tests_require=test_require,
     package_dir={'': 'src'},
-    packages=find_packages('src')
+    packages=find_packages('src'),
+    entry_points={
+        'console_scripts': [
+            'commissaire-storage-service = commissaire_service.storage:main',
+        ],
+    }
 )

--- a/src/commissaire_service/storage/__init__.py
+++ b/src/commissaire_service/storage/__init__.py
@@ -197,12 +197,38 @@ class StorageService(CommissaireService):
         return [model_instance.to_json() for model_instance in model_list]
 
 
-if __name__ == '__main__':
+def main():  # pragma: no cover
+    """
+    Main entry point.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-c', '--config', required=True, type=str,
+        help='Configuration file to use.')
+    parser.add_argument(
+        '--bus-exchange', type=str, default='commissaire',
+        help='Message bus exchange name.')
+    parser.add_argument(
+        '--bus-uri', type=str, metavar='BUS_URI',
+        default='redis://127.0.0.1:6379/',  # FIXME: Remove before release
+        help=(
+            'Message bus connection URI. See:'
+            'http://kombu.readthedocs.io/en/latest/userguide/connections.html')
+    )
+
+    args = parser.parse_args()
+
     try:
         service = StorageService(
-            exchange_name='commissaire',
-            connection_url='redis://127.0.0.1:6379/',
-            config_file=None)
+            exchange_name=args.bus_exchange,
+            connection_url=args.bus_uri,
+            config_file=args.config)
         service.run()
     except KeyboardInterrupt:
         pass
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()


### PR DESCRIPTION
Since I was going to be running the service quite a bit for endpoint development I went ahead and made it runnable.

Note: We probably will want to make a generic parser that services can use once we have more than one service.