### PR TITLE
bug: Fix double encoding issue in storage responses.

### DIFF
--- a/src/commissaire_service/storage/__init__.py
+++ b/src/commissaire_service/storage/__init__.py
@@ -135,12 +135,12 @@ class StorageService(CommissaireService):
         :type model_type_name: str
         :param model_json_data: JSON representation of a model
         :type model_json_data: str
-        :returns: full JSON representation of the model
-        :rtype: str
+        :returns: full dict representation of the model
+        :rtype: dict
         """
         model_instance = self._build_model(model_type_name, model_json_data)
         saved_model_instance = self._manager.save(model_instance)
-        return saved_model_instance.to_json()
+        return saved_model_instance.__dict__
 
     def on_get(self, message, model_type_name, model_json_data):
         """
@@ -155,12 +155,12 @@ class StorageService(CommissaireService):
         :type model_type_name: str
         :param model_json_data: JSON identification of a model
         :type model_json_data: str
-        :returns: full JSON representation of the model
-        :rtype: str
+        :returns: full dict representation of the model
+        :rtype: dict
         """
         model_instance = self._build_model(model_type_name, model_json_data)
         full_model_instance = self._manager.get(model_instance)
-        return full_model_instance.to_json()
+        return full_model_instance.__dict__
 
     def on_delete(self, message, model_type_name, model_json_data):
         """
@@ -189,12 +189,12 @@ class StorageService(CommissaireService):
         :type message: kombu.message.Message
         :param model_type_name: Model type for the JSON data
         :type model_type_name: str
-        :returns: a list of model representations as JSON strings
+        :returns: a list of model representations as dicts
         :rtype: list
         """
         model_type = self._model_types[model_type_name]
         model_list = self._manager.list(model_type.new())
-        return [model_instance.to_json() for model_instance in model_list]
+        return [model_instance.__dict__ for model_instance in model_list]
 
 
 def main():  # pragma: no cover

--- a/src/commissaire_service/storage/__init__.py
+++ b/src/commissaire_service/storage/__init__.py
@@ -140,7 +140,7 @@ class StorageService(CommissaireService):
         """
         model_instance = self._build_model(model_type_name, model_json_data)
         saved_model_instance = self._manager.save(model_instance)
-        return saved_model_instance.__dict__
+        return saved_model_instance.to_dict()
 
     def on_get(self, message, model_type_name, model_json_data):
         """
@@ -160,7 +160,7 @@ class StorageService(CommissaireService):
         """
         model_instance = self._build_model(model_type_name, model_json_data)
         full_model_instance = self._manager.get(model_instance)
-        return full_model_instance.__dict__
+        return full_model_instance.to_dict()
 
     def on_delete(self, message, model_type_name, model_json_data):
         """
@@ -194,7 +194,7 @@ class StorageService(CommissaireService):
         """
         model_type = self._model_types[model_type_name]
         model_list = self._manager.list(model_type.new())
-        return [model_instance.__dict__ for model_instance in model_list]
+        return [model_instance.to_dict() for model_instance in model_list]
 
 
 def main():  # pragma: no cover


### PR DESCRIPTION
This change updates the ``on_*`` methods for the storage service to return
dictionaries rather than json strings. This lets then service framework
handle encoding/decoding and avoid double encoding issues where results
were becoming a proper response with a result being a list of json
strings or ``str``. Now proper responses will have a result as a list of
proper types (the most common being ``dict``) or a specific type.