### PR TITLE
tools: Added etcd_init.sh

### DIFF
--- a/tools/etcd_init.sh
+++ b/tools/etcd_init.sh
@@ -2,11 +2,17 @@
 #
 # Creates the expected etcd directories for Commissaire
 
+echo "+ Creating Commissaire keyspaces..."
 for x in clusters cluster hosts networks status; do
-  etcd_path="commissaire/"$x
-  echo "+ Creating $etcd_path"
+  etcd_path="/commissaire/"$x
+  echo "++ Creating $etcd_path"
   etcdctl mkdir $etcd_path
 done
+
+echo "+ Creating default network configuration..."
+DEFAULT_NETWORK_JSON=`python -c "from commissaire.constants import DEFAULT_CLUSTER_NETWORK_JSON; print(str(DEFAULT_CLUSTER_NETWORK_JSON).replace('\'', '\"'))"`
+etcdctl set /commissaire/networks/default "$DEFAULT_NETWORK_JSON"
+
 
 echo "+ Commissaire etcd namesapce now looks like the following:"
 etcdctl ls --recursive /commissaire/

--- a/tools/etcd_init.sh
+++ b/tools/etcd_init.sh
@@ -2,11 +2,13 @@
 #
 # Creates the expected etcd directories for Commissaire
 
+set -euo pipefail
+
 echo "+ Creating Commissaire keyspaces..."
 for x in clusters cluster hosts networks status; do
   etcd_path="/commissaire/"$x
   echo "++ Creating $etcd_path"
-  etcdctl mkdir $etcd_path
+  etcdctl mkdir $etcd_path || true
 done
 
 echo "+ Creating default network configuration..."

--- a/tools/etcd_init.sh
+++ b/tools/etcd_init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Creates the expected etcd directories for Commissaire
+
+for x in clusters cluster hosts networks status; do
+  etcd_path="commissaire/"$x
+  echo "+ Creating $etcd_path"
+  etcdctl mkdir $etcd_path
+done
+
+echo "+ Commissaire etcd namesapce now looks like the following:"
+etcdctl ls --recursive /commissaire/


### PR DESCRIPTION
Created the ``tools`` directory to house non-required yet helpful tools we may want to provide along with the service code. ``etcd_init.sh`` is the first tool added which initializes the Commissaire etcd keyspace.

Issue originally found by @gbraad while installing ``commissaire-storage-service`` for the first time.