### PR TITLE
Add dependency for Redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-etcd
 requests
 sphinx_rtd_theme
 git+https://github.com/projectatomic/commissaire.git
+redis


### PR DESCRIPTION
Currently for testing Redis has been hard-coded in commissaire-storage-service