### PR TITLE
Watcher Port

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
              'commissaire_service.storage:main'),
             ('commissaire-investigator-service = '
              'commissaire_service.investigator:main'),
+            ('commissaire-watcher-service = '
+             'commissaire_service.watcher:main'),
+
         ],
     }
 )

--- a/src/commissaire_service/data/ansible/playbooks/check_host_availability.yaml
+++ b/src/commissaire_service/data/ansible/playbooks/check_host_availability.yaml
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ---
-- hosts: commissaire_targets
+- hosts: all
   name: Check Host Availability
   gather_facts: no
   tasks:

--- a/src/commissaire_service/transport/ansible_wrapper.py
+++ b/src/commissaire_service/transport/ansible_wrapper.py
@@ -31,7 +31,7 @@ handler.formatter = logging.Formatter('%(name)s - %(message)s')
 logger.addHandler(handler)
 
 
-def get_inventory_file(hosts):
+def get_inventory_file(hosts):  # pragma: no cover
     """
     Set up an --inventory-file option for the Ansible CLI.
 
@@ -52,7 +52,7 @@ def get_inventory_file(hosts):
     return ['--inventory-file', hosts]
 
 
-def gather_facts(host, args=[]):
+def gather_facts(host, args=[]):  # pragma: no cover
     """
     Returns a dictionary of facts gathered by Ansible from a host.
 
@@ -86,7 +86,7 @@ def gather_facts(host, args=[]):
         raise error
 
 
-def execute_playbook(playbook, hosts, args=[]):
+def execute_playbook(playbook, hosts, args=[]):  # pragma: no cover
     """
     Executes a playbook file for the given set of hosts, passing any
     additional command-line arguments to the playbook command.

--- a/src/commissaire_service/transport/ansibleapi.py
+++ b/src/commissaire_service/transport/ansibleapi.py
@@ -26,7 +26,7 @@ from time import sleep
 from .ansible_wrapper import gather_facts, execute_playbook
 
 
-class Transport:
+class Transport:  # pragma: no cover
     """
     Transport using Ansible.
     """

--- a/src/commissaire_service/watcher/__init__.py
+++ b/src/commissaire_service/watcher/__init__.py
@@ -1,0 +1,174 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+The host node watcher.
+"""
+
+import json
+
+from datetime import datetime, timedelta
+from time import sleep
+
+from commissaire import constants as C
+from commissaire.models import Host, WatcherRecord
+from commissaire.util.ssh import TemporarySSHKey
+
+from commissaire_service.service import CommissaireService
+from commissaire_service.transport import ansibleapi
+
+
+class WatcherService(CommissaireService):
+    """
+    Periodically connects to hosts to check their status.
+    """
+
+    def __init__(self, exchange_name, connection_url):
+        """
+        Creates a new WatcherService.
+
+        :param exchange_name: Name of the topic exchange
+        :type exchange_name: str
+        :param connection_url: Kombu connection URL
+        :type connection_url: str
+        """
+        queue_kwargs = [{
+            'name': 'watcher',
+            'exclusive': False,
+            'routing_key': 'jobs.watcher',
+        }]
+        # Store the last address seen for backoff
+        self.last_address = None
+        super().__init__(exchange_name, connection_url, queue_kwargs)
+
+    def on_message(self, body, message):
+        """
+        Called when a non-jsonrpc message arrives.
+
+        :param body: Body of the message.
+        :type body: dict
+        :param message: The message instance.
+        :type message: kombu.message.Message
+        """
+        record = WatcherRecord(**json.loads(body))
+        # Ack the message so it does not requeue on it's own
+        message.ack()
+        self.logger.debug(
+            'Checking on WatcherQueue item: {}'.format(record.to_json()))
+        if datetime.strptime(record.last_check, C.DATE_FORMAT) < (
+                datetime.utcnow() - timedelta(minutes=1)):
+            try:
+                self._check(record.address)
+            except Exception as error:
+                self.logger.debug('Error: {}: {}'.format(type(error), error))
+            record.last_check = datetime.utcnow().isoformat()
+        else:
+            if self.last_address == record.address:
+                # Since we got the same address we could process twice
+                # back off a little extra
+                self.logger.debug(
+                    'Got "{}" twice. Backing off...'.format(record.address))
+                sleep(10)
+            else:
+                # Since the top item wasn't ready for processing sleep a bit
+                sleep(2)
+        self.last_address = record.address
+        # Requeue the host
+        self.producer.publish(record.to_json(), 'jobs.watcher')
+
+    def _check(self, address):
+        """
+        Initiates an check on the requested host.
+
+        :param address: Host address to investigate
+        :type address: str
+        :param cluster_data: Optional data for the associated cluster
+        :type cluster_data: dict
+        """
+        # Statuses follow:
+        # http://commissaire.readthedocs.org/en/latest/enums.html#host-statuses
+
+        self.logger.info('Checking host "{}".'.format(address))
+        try:
+            response = self.request('storage.get', params={
+                'model_type_name': 'Host',
+                'model_json_data': Host.new(address=address).to_json(),
+                'secure': True,
+            })
+            host = Host.new(**response['result'])
+        except Exception as error:
+            self.logger.warn(
+                'Unable to continue for host "{}" due to '
+                '{}: {}. Returning...'.format(address, type(error), error))
+            raise error
+
+        transport = ansibleapi.Transport(host.remote_user)
+
+        with TemporarySSHKey(host, self.logger) as key:
+            try:
+                self.logger.debug(
+                    'Starting watcher run for host "{}"'.format(address))
+                result = transport.check_host_availability(host, key.path)
+                host.last_check = datetime.utcnow().isoformat()
+                self.logger.debug(
+                    'Watcher result for host {}: {}'.format(address, result))
+            except Exception as error:
+                self.logger.warn(
+                    'Failed to connect to host node "{}"'.format(address))
+                self.logger.debug(
+                    'Watcher failed for host node "{}" with {}: {}'.format(
+                        address, str(error), error))
+                host.status = 'failed'
+                raise error
+            finally:
+                # Save the model
+                self.request('storage.save', params={
+                    'model_type_name': host.__class__.__name__,
+                    'model_json_data': host.to_json(),
+                })
+            self.logger.info(
+                'Finished watcher run for host "{}"'.format(address))
+
+
+def main():  # pragma: no cover
+    """
+    Main entry point.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--bus-exchange', type=str, default='commissaire',
+        help='Message bus exchange name.')
+    parser.add_argument(
+        '--bus-uri', type=str, metavar='BUS_URI',
+        default='redis://127.0.0.1:6379/',  # FIXME Remove before release
+        help=(
+            'Message bus connection URI. See:'
+            'http://kombu.readthedocs.io/en/latest/userguide/connections.html')
+    )
+
+    args = parser.parse_args()
+
+    try:
+        service = WatcherService(
+            exchange_name=args.bus_exchange,
+            connection_url=args.bus_uri)
+        service.run()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/test/test_service_commissaireservice.py
+++ b/test/test_service_commissaireservice.py
@@ -94,7 +94,7 @@ class TestCommissaireService(TestCase):
         self.assertEquals(1, len(consumers))
         # With 1 callback pointing to the message wrapper
         Consumer.assert_called_once_with(
-            mock.ANY, callbacks=[self.service_instance._wrap_on_message])
+            mock.ANY, callbacks=[self.service_instance.on_message])
 
     def test_on_message(self):
         """
@@ -124,9 +124,9 @@ class TestCommissaireService(TestCase):
         self.service_instance.connection.SimpleQueue.__call__(
             ).close.assert_called_once_with()
 
-    def test__wrap_on_message_with_exposed_method(self):
+    def test_on_message_with_exposed_method(self):
         """
-        Verify ServiceManager._wrap_on_message routes requests properly.
+        Verify ServiceManager.on_message routes requests properly.
         """
         body = {
             'jsonrpc': '2.0',
@@ -139,14 +139,14 @@ class TestCommissaireService(TestCase):
             properties={'reply_to': 'test_queue'},
             delivery_info={'routing_key': 'test.method'})
         self.service_instance.on_method = mock.MagicMock(return_value='{}')
-        self.service_instance._wrap_on_message(body, message)
+        self.service_instance.on_message(body, message)
         # The on_method should have been called
         self.service_instance.on_method.assert_called_once_with(
             kwarg='value', message=message)
 
-    def test__wrap_on_message_without_exposed_method(self):
+    def test_on_message_without_exposed_method(self):
         """
-        Verify ServiceManager._wrap_on_message returns error if method doesn't exist.
+        Verify ServiceManager.on_message returns error if method doesn't exist.
         """
         body = {
             'jsonrpc': '2.0',
@@ -158,18 +158,18 @@ class TestCommissaireService(TestCase):
             payload=body,
             properties={'reply_to': 'test_queue'},
             delivery_info={'routing_key': 'test.doesnotexist'})
-        self.service_instance._wrap_on_message(body, message)
+        self.service_instance.on_message(body, message)
         self.service_instance.connection.SimpleQueue.assert_called_once_with(
             'test_queue')
 
-    def test__wrap_on_message_with_bad_message(self):
+    def test_on_message_with_bad_message(self):
         """
-        Verify ServiceManager._wrap_on_message forwards to on_message on non jsonrpc messages.
+        Verify ServiceManager.on_message forwards to on_message on non jsonrpc messages.
         """
         self.service_instance.on_message =  mock.MagicMock()
         body = '[]'
         message = mock.MagicMock(
             payload=body,
             properties={'reply_to': 'test_queue'})
-        self.service_instance._wrap_on_message(body, message)
+        self.service_instance.on_message(body, message)
         self.assertEquals(1, self.service_instance.on_message.call_count)

--- a/test/test_service_watcher.py
+++ b/test/test_service_watcher.py
@@ -1,0 +1,139 @@
+# Copyright (C) 2016  Red Hat, Inc
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Tests for commissaire_service.service.watcher module.
+"""
+
+import datetime
+
+from . import TestCase, mock
+
+from commissaire import models
+from commissaire_service.watcher import WatcherService
+
+
+class TestCommissaireService(TestCase):
+    """
+    Tests for the CommissaireService class.
+    """
+
+    def setUp(self):
+        self._connection_patcher = mock.patch(
+            'commissaire_service.service.Connection')
+        self._exchange_patcher = mock.patch(
+            'commissaire_service.service.Exchange')
+        self._producer_patcher = mock.patch(
+            'commissaire_service.service.Producer')
+        self._connection = self._connection_patcher.start()
+        self._exchange = self._exchange_patcher.start()
+        self._producer = self._producer_patcher.start()
+
+        self.queue_kwargs = [
+            {'name': 'simple', 'routing_key': 'simple.*'},
+        ]
+
+        self.service_instance = WatcherService(
+            'commissaire',
+            'redis://127.0.0.1:6379/'
+        )
+
+    def tearDown(self):
+        self._connection.stop()
+        self._exchange.stop()
+        self._producer.stop()
+
+    def test_on_message_with_success(self):
+        """
+        Verify WatcherService.on_message handles a successful message properly.
+        """
+        body = models.WatcherRecord(
+            address='127.0.0.1',
+            last_check=(datetime.datetime.utcnow() - datetime.timedelta(
+                    minutes=10)).isoformat())
+        message = mock.MagicMock(
+            payload=body.to_json(),
+            delivery_info={'routing_key': 'jobs.watcher'})
+
+        self.service_instance._check = mock.MagicMock()
+        self.service_instance.on_message(body.to_json(), message)
+        # The message must get ack'd
+        message.ack.assert_called_once_with()
+        # Check should be called
+        self.service_instance._check.assert_called_once_with('127.0.0.1')
+
+    def test_on_message_with_bad_connection(self):
+        """
+        Verify WatcherService.on_message handles bad connections properly.
+        """
+        body = models.WatcherRecord(
+            address='127.0.0.1',
+            last_check=(datetime.datetime.utcnow() - datetime.timedelta(
+                    minutes=10)).isoformat())
+        message = mock.MagicMock(
+            payload=body.to_json(),
+            delivery_info={'routing_key': 'jobs.watcher'})
+
+        self.service_instance._check = mock.MagicMock(
+            side_effect=Exception('test'))
+        self.service_instance.on_message(body.to_json(), message)
+        # The message must get ack'd
+        message.ack.assert_called_once_with()
+        # Check should be called
+        self.service_instance._check.assert_called_once_with('127.0.0.1')
+
+    def test_on_message_with_early_address(self):
+        """
+        Verify WatcherService.on_message requeues addresses that have been checked recently.
+        """
+        with mock.patch('commissaire_service.watcher.sleep') as _sleep:
+            body = models.WatcherRecord(
+                address='127.0.0.1',
+                last_check=datetime.datetime.utcnow().isoformat())
+            message = mock.MagicMock(
+                payload=body.to_json(),
+                delivery_info={'routing_key': 'jobs.watcher'})
+
+            self.service_instance._check = mock.MagicMock()
+            self.service_instance.on_message(body.to_json(), message)
+            # The message must get ack'd
+            message.ack.assert_called_once_with()
+            # Check should NOT be called
+            self.assertEquals(0, self.service_instance._check.call_count)
+            # We should have been asked to sleep
+            _sleep.assert_called_once_with(mock.ANY)
+
+    def test__check_with_no_errors(self):
+        """
+        Verify _check works in a perfect scenario.
+        """
+        with mock.patch(
+                'commissaire_service.transport.ansibleapi.Transport') as _transport:
+            transport = _transport()
+
+            self.service_instance.request = mock.MagicMock(
+                side_effect=(
+                    # Getting the host
+                    {'result': {
+                        'address': '127.0.0.1',
+                        'last_check': datetime.datetime.min.isoformat()
+                    }},
+                    # The save
+                    None))
+            self.service_instance._check('127.0.0.1')
+            # The transport method should have been called once
+            self.assertEquals(1, transport.check_host_availability.call_count)
+            # Verify the last request was a save
+            self.service_instance.request.assert_called_with(
+                'storage.save', params=mock.ANY)


### PR DESCRIPTION
- Disable ansible code test coverage.
- Added watcher service.
- CommissaireService simplification.
- Use entire inventory for availability check.

Requires: https://github.com/projectatomic/commissaire/pull/36