### PR TITLE
Added new style params to flanneld template

### DIFF
--- a/src/commissaire_service/data/templates/flanneld
+++ b/src/commissaire_service/data/templates/flanneld
@@ -1,8 +1,12 @@
 {%- set OPTIONS="" %}
 
 {%- if commissaire_etcd_server_url is defined %}
+# Old style options
 FLANNEL_ETCD="{{ commissaire_etcd_server_url }}"
 FLANNEL_ETCD_KEY="{{ commissaire_flannel_key }}"
+# New style options
+FLANNEL_ETCD_ENDPOINTS="{{ commissaire_etcd_server_url }}"
+FLANNEL_ETCD_PREFIX="{{ commissaire_flannel_key }}"
 {%- elif commissaire_flanneld_server is defined %}
 {#- commissaire_flanneld_server indicates a client/server model #}
 {%- set OPTIONS=OPTIONS ~ "--remote=" ~ commissaire_flanneld_server ~ " " %}


### PR DESCRIPTION
The names of the params that pass into the flanneld have changed. This
change adds the new parameters and keeps the old ones as well as they do
not collide.