### PR TITLE
service: Added bus-uri and exchange-name to config files

### DIFF
--- a/conf/clusterexec.conf
+++ b/conf/clusterexec.conf
@@ -1,3 +1,4 @@
 {
+  "bus_uri": "redis://127.0.0.1:6379",
   "debug": false
 }

--- a/conf/containermgr.conf
+++ b/conf/containermgr.conf
@@ -1,4 +1,5 @@
 {
+  "bus_uri": "redis://127.0.0.1:6379",
   "container_handlers": [
     {
       "name": "OpenshiftA1",

--- a/conf/investigator.conf
+++ b/conf/investigator.conf
@@ -1,3 +1,4 @@
 {
-  "debug": false
+  "debug": false,
+  "bus_uri": "redis://127.0.0.1:6379"
 }

--- a/conf/storage.conf
+++ b/conf/storage.conf
@@ -1,4 +1,5 @@
 {
+  "bus_uri": "redis://127.0.0.1:6379",
   "storage_handlers": [
     {
       "type": "etcd",

--- a/conf/watcher.conf
+++ b/conf/watcher.conf
@@ -1,3 +1,4 @@
 {
+  "bus_uri": "redis://127.0.0.1:6379",
   "debug": false
 }

--- a/src/commissaire_service/clusterexec/__init__.py
+++ b/src/commissaire_service/clusterexec/__init__.py
@@ -33,6 +33,9 @@ class ClusterExecService(CommissaireService):
     Executes operations over a cluster by way of remote shell commands.
     """
 
+    #: Default configuration file
+    _default_config_file = '/etc/commissaire/clusterexec.conf'
+
     def __init__(self, exchange_name, connection_url, config_file=None):
         """
         Creates a new ClusterExecService.  If config_file is omitted,
@@ -53,7 +56,7 @@ class ClusterExecService(CommissaireService):
             exchange_name,
             connection_url,
             queue_kwargs,
-            config_files=(config_file, '/etc/commissaire/clusterexec.conf'))
+            config_file=config_file)
 
         self.storage = StorageClient(self)
 

--- a/src/commissaire_service/clusterexec/__init__.py
+++ b/src/commissaire_service/clusterexec/__init__.py
@@ -19,7 +19,6 @@ from commissaire import constants as C
 from commissaire.models import (
     ClusterDeploy, ClusterUpgrade, ClusterRestart)
 from commissaire.storage.client import StorageClient
-from commissaire.util.config import read_config_file
 from commissaire.util.date import formatted_dt
 from commissaire.util.ssh import TemporarySSHKey
 
@@ -49,11 +48,14 @@ class ClusterExecService(CommissaireService):
         queue_kwargs = [
             {'routing_key': 'jobs.clusterexec.*'}
         ]
-        super().__init__(exchange_name, connection_url, queue_kwargs)
-        self.storage = StorageClient(self)
 
-        # Apply any logging configuration for this service.
-        read_config_file(config_file, '/etc/commissaire/clusterexec.conf')
+        super().__init__(
+            exchange_name,
+            connection_url,
+            queue_kwargs,
+            config_files=(config_file, '/etc/commissaire/clusterexec.conf'))
+
+        self.storage = StorageClient(self)
 
     def _execute(self, message, model_instance, command_args,
                  finished_hosts_key):

--- a/src/commissaire_service/containermgr/__init__.py
+++ b/src/commissaire_service/containermgr/__init__.py
@@ -29,6 +29,9 @@ class ContainerManagerService(CommissaireService):
     Provides access to Container Managers.
     """
 
+    #: Default configuration file
+    _default_config_file = '/etc/commissaire/containermgr.conf'
+
     def __init__(self, exchange_name, connection_url, config_file=None):
         """
         Creates a new ContainerManagerService.  If config_file is omitted,
@@ -50,7 +53,7 @@ class ContainerManagerService(CommissaireService):
             exchange_name,
             connection_url,
             queue_kwargs,
-            config_files=(config_file, '/etc/commissaire/containermgr.conf'))
+            config_file=config_file)
 
         self.storage = StorageClient(self)
         self.managers = {}

--- a/src/commissaire_service/containermgr/__init__.py
+++ b/src/commissaire_service/containermgr/__init__.py
@@ -18,7 +18,7 @@ from commissaire import models
 from commissaire.bus import ContainerManagerError
 from commissaire.containermgr import ContainerManagerBase
 from commissaire.storage.client import StorageClient
-from commissaire.util.config import read_config_file, import_plugin
+from commissaire.util.config import import_plugin
 
 from commissaire_service.service import (
     CommissaireService, add_service_arguments)
@@ -46,12 +46,14 @@ class ContainerManagerService(CommissaireService):
             'routing_key': 'container.*',
             'exclusive': False,
         }]
-        super().__init__(exchange_name, connection_url, queue_kwargs)
+        super().__init__(
+            exchange_name,
+            connection_url,
+            queue_kwargs,
+            config_files=(config_file, '/etc/commissaire/containermgr.conf'))
+
         self.storage = StorageClient(self)
         self.managers = {}
-
-        # Apply any logging configuration for this service.
-        read_config_file(config_file, '/etc/commissaire/containermgr.conf')
 
     def refresh_managers(self):
         """

--- a/src/commissaire_service/investigator/__init__.py
+++ b/src/commissaire_service/investigator/__init__.py
@@ -34,6 +34,9 @@ class InvestigatorService(CommissaireService):
     Investigates new hosts to retrieve and store facts.
     """
 
+    #: Default configuration file
+    _default_config_file = '/etc/commissaire/investigator.conf'
+
     def __init__(self, exchange_name, connection_url, config_file=None):
         """
         Creates a new InvestigatorService.  If config_file is omitted,
@@ -54,7 +57,7 @@ class InvestigatorService(CommissaireService):
             exchange_name,
             connection_url,
             queue_kwargs,
-            config_files=(config_file, '/etc/commissaire/investigator.conf'))
+            config_files=config_file)
 
         self.storage = StorageClient(self)
 

--- a/src/commissaire_service/investigator/__init__.py
+++ b/src/commissaire_service/investigator/__init__.py
@@ -19,7 +19,7 @@ import commissaire.constants as C
 
 from commissaire.models import Cluster, Host, Network
 from commissaire.storage.client import StorageClient
-from commissaire.util.config import ConfigurationError, read_config_file
+from commissaire.util.config import ConfigurationError
 from commissaire.util.date import formatted_dt
 from commissaire.util.ssh import TemporarySSHKey
 
@@ -49,11 +49,14 @@ class InvestigatorService(CommissaireService):
         queue_kwargs = [
             {'routing_key': 'jobs.investigate'}
         ]
-        super().__init__(exchange_name, connection_url, queue_kwargs)
-        self.storage = StorageClient(self)
 
-        # Apply any logging configuration for this service.
-        read_config_file(config_file, '/etc/commissaire/investigator.conf')
+        super().__init__(
+            exchange_name,
+            connection_url,
+            queue_kwargs,
+            config_files=(config_file, '/etc/commissaire/investigator.conf'))
+
+        self.storage = StorageClient(self)
 
     def _get_etcd_config(self):
         """

--- a/src/commissaire_service/service/__init__.py
+++ b/src/commissaire_service/service/__init__.py
@@ -74,6 +74,7 @@ class ServiceManager:
     """
     Multiprocessed Service Manager.
     """
+
     def __init__(self, service_class, process_count, exchange_name,
                  connection_url, qkwargs, **kwargs):
         """
@@ -144,7 +145,12 @@ class CommissaireService(ConsumerMixin, BusMixin):
     Commissaire service class.
     """
 
-    def __init__(self, exchange_name, connection_url, qkwargs, config_files):
+    #: Default configuration file if none is specified. Subclasses
+    #: should override this.
+    _default_config_file = C.DEFAULT_CONFIGURATION_FILE
+
+    def __init__(
+            self, exchange_name, connection_url, qkwargs, config_file=None):
         """
         Initializes a new Service instance.
 
@@ -154,22 +160,17 @@ class CommissaireService(ConsumerMixin, BusMixin):
         :type connection_url: str
         :param qkwargs: One or more dicts keyword arguments for queue creation
         :type qkwargs: list
-        :param config_files: Paths to the configuration file locations.
-        :type config_files: tuple(str, str)
+        :param config_file: Path to the configuration file location.
+        :type config_file: str or None
         """
         name = self.__class__.__name__
         self.logger = logging.getLogger(name)
         self.logger.debug('Initializing {}'.format(name))
 
-        self._config_data = {}
-
         # If we are given no default, use the global one
-        if len(config_files) > 0 and config_files[1] is None:
-            config_files = list(config_files)
-            config_files[1] = C.DEFAULT_CONFIGURATION_FILE
-
         # Read the configuration file
-        self._config_data = read_config_file(*config_files)
+        self._config_data = read_config_file(
+            config_file, self._default_config_file)
 
         if connection_url is None and 'bus_uri' in self._config_data:
             connection_url = self._config_data.get('bus_uri')

--- a/src/commissaire_service/storage/__init__.py
+++ b/src/commissaire_service/storage/__init__.py
@@ -33,6 +33,9 @@ class StorageService(CommissaireService):
     Provides access to data stores to other services.
     """
 
+    #: Default configuration file
+    _default_config_file = '/etc/commissaire/storage.conf'
+
     def __init__(self, exchange_name, connection_url, config_file=None):
         """
         Creates a new StorageService and sets up StoreHandler instances
@@ -54,7 +57,7 @@ class StorageService(CommissaireService):
             exchange_name,
             connection_url,
             queue_kwargs,
-            config_files=(config_file, '/etc/commissaire/storage.conf'))
+            config_file=config_file)
 
         self._manager = StoreHandlerManager()
 

--- a/src/commissaire_service/storage/__init__.py
+++ b/src/commissaire_service/storage/__init__.py
@@ -20,8 +20,7 @@ import commissaire.models as models
 
 from commissaire import constants as C
 from commissaire.storage import StoreHandlerBase
-from commissaire.util.config import (
-    ConfigurationError, read_config_file, import_plugin)
+from commissaire.util.config import (ConfigurationError, import_plugin)
 
 from commissaire_service.service import (
     CommissaireService, add_service_arguments)
@@ -50,7 +49,12 @@ class StorageService(CommissaireService):
         queue_kwargs = [
             {'routing_key': 'storage.*'},
         ]
-        super().__init__(exchange_name, connection_url, queue_kwargs)
+
+        super().__init__(
+            exchange_name,
+            connection_url,
+            queue_kwargs,
+            config_files=(config_file, '/etc/commissaire/storage.conf'))
 
         self._manager = StoreHandlerManager()
 
@@ -59,9 +63,7 @@ class StorageService(CommissaireService):
                              if isinstance(v, type) and
                              issubclass(v, models.Model)}
 
-        config_data = read_config_file(
-            config_file, '/etc/commissaire/storage.conf')
-        store_handlers = config_data.get('storage_handlers', [])
+        store_handlers = self._config_data.get('storage_handlers', [])
 
         # Configure store handlers from user data.
         if len(store_handlers) == 0:

--- a/src/commissaire_service/watcher/__init__.py
+++ b/src/commissaire_service/watcher/__init__.py
@@ -37,6 +37,9 @@ class WatcherService(CommissaireService):
     Periodically connects to hosts to check their status.
     """
 
+    #: Default configuration file
+    _default_config_file = '/etc/commissaire/watcher.conf'
+
     def __init__(self, exchange_name, connection_url, config_file=None):
         """
         Creates a new WatcherService.  If config_file is omitted,
@@ -61,7 +64,7 @@ class WatcherService(CommissaireService):
             exchange_name,
             connection_url,
             queue_kwargs,
-            config_files=(config_file, '/etc/commissaire/watcher.conf'))
+            config_file=config_file)
 
         self.storage = StorageClient(self)
 

--- a/src/commissaire_service/watcher/__init__.py
+++ b/src/commissaire_service/watcher/__init__.py
@@ -24,7 +24,6 @@ from time import sleep
 from commissaire import constants as C
 from commissaire.models import WatcherRecord
 from commissaire.storage.client import StorageClient
-from commissaire.util.config import read_config_file
 from commissaire.util.date import formatted_dt
 from commissaire.util.ssh import TemporarySSHKey
 
@@ -57,11 +56,14 @@ class WatcherService(CommissaireService):
         }]
         # Store the last address seen for backoff
         self.last_address = None
-        super().__init__(exchange_name, connection_url, queue_kwargs)
-        self.storage = StorageClient(self)
 
-        # Apply any logging configuration for this service.
-        read_config_file(config_file, '/etc/commissaire/watcher.conf')
+        super().__init__(
+            exchange_name,
+            connection_url,
+            queue_kwargs,
+            config_files=(config_file, '/etc/commissaire/watcher.conf'))
+
+        self.storage = StorageClient(self)
 
     def on_message(self, body, message):
         """

--- a/test/test_service_commissaireservice.py
+++ b/test/test_service_commissaireservice.py
@@ -48,7 +48,8 @@ class TestCommissaireService(TestCase):
         self.service_instance = CommissaireService(
             'commissaire',
             'redis://127.0.0.1:6379/',
-            self.queue_kwargs
+            self.queue_kwargs,
+            (None, None)
         )
 
     def tearDown(self):

--- a/test/test_service_commissaireservice.py
+++ b/test/test_service_commissaireservice.py
@@ -48,8 +48,7 @@ class TestCommissaireService(TestCase):
         self.service_instance = CommissaireService(
             'commissaire',
             'redis://127.0.0.1:6379/',
-            self.queue_kwargs,
-            (None, None)
+            self.queue_kwargs
         )
 
     def tearDown(self):


### PR DESCRIPTION
Service configuration files can now include the bus-uri, bus_exchange,
and any other set of information needed to run the service.

Requires: https://github.com/projectatomic/commissaire/pull/126